### PR TITLE
wave: Update sampleCount to frameCount

### DIFF
--- a/src/rres-raylib.h
+++ b/src/rres-raylib.h
@@ -135,12 +135,12 @@ Wave rresLoadWave(rresData rres)
 
     if ((rres.count >= 1) && (rres.chunks[0].type == RRES_DATA_WAVE))
     {
-        wave.sampleCount = rres.chunks[0].props[0];
+        wave.frameCount = rres.chunks[0].props[0];
         wave.sampleRate = rres.chunks[0].props[1];
         wave.sampleSize = rres.chunks[0].props[2];
         wave.channels = rres.chunks[0].props[3];
 
-        unsigned int size = wave.sampleCount*wave.sampleSize/8;
+        unsigned int size = wave.frameCount*wave.sampleSize/8;
         wave.data = RL_MALLOC(size);
         memcpy(wave.data, rres.chunks[0].data, size);
     }


### PR DESCRIPTION
Was getting an error that Wave had no member named sampleCount. Has this been moved to frameCount?

With this change, however, I am getting a segfault on data_loading...
```
WARNING: CDIR: Found at offset: 0017b1f4
WARNING: CDIR: Found! Comp.Size: 258
INFO: FILE: [EE4E0E4E] Entry (0xc): C:\GitHub\rres\examples\resources\text_data.txt (len: 48)
INFO: FILE: [3D372B5D] Entry (0x54): C:\GitHub\rres\examples\resources\images\cat.png (len: 49)
INFO: FILE: [75588D7D] Entry (0x90088): C:\GitHub\rres\examples\resources\images\fudesumi.png (len: 54)
INFO: FILE: [4FFCAC28] Entry (0x1500bc): C:\GitHub\rres\examples\resources\audio\target.ogg (len: 51)
INFO: TEXTURE: [ID 3] Texture loaded successfully (384x512 | R8G8B8A8 | 1 mipmaps)
INFO: WAVE: Unloaded wave data from RAM
[1]    44513 segmentation fault (core dumped)  ./rres_data_loading
```