### PR TITLE
Fix example code.

### DIFF
--- a/examples/rres_load_image.c
+++ b/examples/rres_load_image.c
@@ -41,7 +41,7 @@ int main(void)
     rresResourceChunk chunk = rresLoadResourceChunk("resources.rres", id);
     
     // Decompress/decipher resource data (if required)
-    result = UnpackResourceChunk(&chunk);
+    int result = UnpackResourceChunk(&chunk);
     
     if (result == RRES_SUCCESS)         // Data decompressed/decrypted successfully
     {

--- a/examples/rres_load_image.c
+++ b/examples/rres_load_image.c
@@ -12,13 +12,13 @@
 #include "raylib.h"
 
 #define RRES_IMPLEMENTATION
-#include "rres/rres.h"              // Required to read rres data chunks
+#include "../src/rres.h"              // Required to read rres data chunks
 
 #define RRES_RAYLIB_IMPLEMENTATION
 #define RRES_SUPPORT_COMPRESSION_LZ4
 #define RRES_SUPPORT_ENCRYPTION_AES
 #define RRES_SUPPORT_ENCRYPTION_XCHACHA20
-#include "rres/rres-raylib.h"       // Required to map rres data chunks into raylib structs
+#include "../src/rres-raylib.h"       // Required to map rres data chunks into raylib structs
 
 int main(void)
 {


### PR DESCRIPTION
`examples/rres_load_image.c` had incorrect include paths, this pull request updates the include paths to the same as the other examples, allowing it to be built again. Line 44 was also missing the type, this has been fixed