### PR TITLE
Fix a compilation issue for C++

### DIFF
--- a/src/rres-raylib.h
+++ b/src/rres-raylib.h
@@ -736,7 +736,7 @@ int UnpackResourceChunk(rresResourceChunk *chunk)
             {
                 int uncompDataSize = 0;
                 uncompData = (unsigned char *)RRES_CALLOC(chunk->info.baseSize, 1);
-                uncompDataSize = LZ4_decompress_safe(decryptedData, uncompData, chunk->info.packedSize, chunk->info.baseSize);
+                uncompDataSize = LZ4_decompress_safe((char *)decryptedData, (char *)uncompData, chunk->info.packedSize, chunk->info.baseSize);
 
                 if ((uncompData != NULL) && (uncompDataSize > 0))     // Decompression successful
                 {


### PR DESCRIPTION
This is a fix for problems encountered when compiling with `g++` when including `rres-raylib.h` from a C++ source.
See issues: https://github.com/raysan5/rres/issues/21 https://github.com/raysan5/rres/issues/18