### PR TITLE
Fix stereo wave format not parsed correctly

### DIFF
--- a/src/rres-raylib.h
+++ b/src/rres-raylib.h
@@ -273,7 +273,7 @@ Wave LoadWaveFromResource(rresResourceChunk chunk)
             wave.sampleSize = chunk.data.props[2];
             wave.channels = chunk.data.props[3];
 
-            unsigned int size = wave.frameCount*wave.sampleSize/8;
+            unsigned int size = wave.frameCount*wave.sampleSize*wave.channels/8;
             wave.data = RL_CALLOC(size, 1);
             memcpy(wave.data, chunk.data.raw, size);
         }


### PR DESCRIPTION
Fixes #13 

LoadWaveFromResource did not use the channel parameter to calculate the size of the wave data, thus incorrectly loads stereo wave audio.

Adjust the calculation to use the number of channels

Tested on Linux Mint 21.2 Cinnamon 5.8.4, kernel version 5.15.0-105-generic, x86_64

The test involves loading a RRES file containing a stereo wave audio and the original stereo wave file, and playing them. The audio is generated with rFXGen. The files tested can be found here.
[wavecheck.zip](https://github.com/raysan5/rres/files/15050918/wavecheck.zip)

Test code:
```c
#include "raylib.h"

#define RRES_IMPLEMENTATION
#include "rres.h"

#define RRES_RAYLIB_IMPLEMENTATION
#define RRES_SUPPORT_COMPRESSION_LZ4
#include "rres-raylib.h"

#include <stdio.h>
#include <string.h>

#define FILE_NAME "test" // Change this
#define RRES_FILE FILE_NAME ".rres"
#define WAV_FILE FILE_NAME ".wav"

int main(void)
{
    InitWindow(800, 600, "raylib");
    InitAudioDevice();
    SetTargetFPS(60);

    // Rres load
    Sound sound = {0};
    rresCentralDir dir = rresLoadCentralDirectory(RRES_FILE);
    uint32_t id = rresGetResourceId(dir, WAV_FILE);
    rresResourceChunk chunk = rresLoadResourceChunk(RRES_FILE, id);
    Wave wave = LoadWaveFromResource(chunk);
    printf("%d %d %d %d\n", wave.frameCount, wave.sampleRate, wave.sampleSize, wave.channels);
    sound = LoadSoundFromWave(wave);

    // Direct load
    Sound originalSound = {0};
    Wave originalWave = LoadWave(WAV_FILE);
    printf("%d %d %d %d\n", wave.frameCount, wave.sampleRate, wave.sampleSize, wave.channels);
    originalSound = LoadSoundFromWave(wave);

    unsigned int size = originalWave.frameCount*originalWave.sampleSize*originalWave.channels/8;
    printf("Memory compare size %u : %s\n", size, (memcmp(wave.data, originalWave.data, size) == 0) ? "OK" : "NOT OK");
    UnloadWave(wave);
    UnloadWave(originalWave);

    while (!WindowShouldClose())
    {

        if (IsKeyReleased(KEY_P)) PlaySound(sound);
        if (IsKeyReleased(KEY_O)) PlaySound(originalSound);

        BeginDrawing();
            ClearBackground(BLACK);
            DrawText("Wave Test", 20, 20, 30, RAYWHITE);
        EndDrawing();
    }

    UnloadSound(sound);
    UnloadSound(originalSound);
    CloseAudioDevice();
    CloseWindow();
}
```
Expected result: With the fix, the code should be able to play the stereo audio correctly, both from RRES file and the original wave file. The code should also be able to play the mono audio as well.