### PR TITLE
Hash functions take data as const

### DIFF
--- a/src/rres-raylib.h
+++ b/src/rres-raylib.h
@@ -168,7 +168,7 @@ static char *LoadTextFromResourceChunk(rresResourceChunk chunk, unsigned int *co
 static Image LoadImageFromResourceChunk(rresResourceChunk chunk);                        // Load chunk: RRES_DATA_IMAGE
 
 static const char *GetExtensionFromProps(unsigned int ext01, unsigned int ext02);        // Get file extension from RRES_DATA_RAW properties (unsigned int) 
-static unsigned int *ComputeMD5(unsigned char *data, int size);                          // Compute MD5 hash code, returns 4 integers array (static)
+static unsigned int *ComputeMD5(const unsigned char *data, int size);                    // Compute MD5 hash code, returns 4 integers array (static)
 
 //----------------------------------------------------------------------------------
 // Module Functions Definition
@@ -976,7 +976,7 @@ static const char *GetExtensionFromProps(unsigned int ext01, unsigned int ext02)
 }
 
 // Compute MD5 hash code, returns 4 integers array (static)
-static unsigned int *ComputeMD5(unsigned char *data, int size)
+static unsigned int *ComputeMD5(const unsigned char *data, int size)
 {
 #define LEFTROTATE(x, c) (((x) << (c)) | ((x) >> (32 - (c))))
 

--- a/src/rres.h
+++ b/src/rres.h
@@ -504,7 +504,7 @@ RRESAPI void rresUnloadCentralDirectory(rresCentralDir dir);                    
 RRESAPI unsigned int rresGetDataType(const unsigned char *fourCC);                  // Get rresResourceDataType from FourCC code
 RRESAPI int rresGetResourceId(rresCentralDir dir, const char *fileName);            // Get resource id for a provided filename
                                                                                     // NOTE: It requires CDIR available in the file (it's optinal by design)
-RRESAPI unsigned int rresComputeCRC32(unsigned char *data, int len);                // Compute CRC32 for provided data
+RRESAPI unsigned int rresComputeCRC32(const unsigned char *data, int len);          // Compute CRC32 for provided data
 
 // Manage password for data encryption/decryption
 // NOTE: The cipher password is kept as an internal pointer to provided string, it's up to the user to manage that sensible data properly
@@ -987,7 +987,7 @@ int rresGetResourceId(rresCentralDir dir, const char *fileName)
 
 // Compute CRC32 hash
 // NOTE: CRC32 is used as rres id, generated from original filename
-unsigned int rresComputeCRC32(unsigned char *data, int len)
+unsigned int rresComputeCRC32(const unsigned char *data, int len)
 {
     static unsigned int crcTable[256] = {
         0x00000000, 0x77073096, 0xEE0E612C, 0x990951BA, 0x076DC419, 0x706AF48F, 0xE963A535, 0x9E6495A3,


### PR DESCRIPTION
These functions do not need to modify the data buffer provided. Making them const allows easier use.