### PR TITLE
fixed C++ issue compatibility

### DIFF
--- a/src/rres-raylib.h
+++ b/src/rres-raylib.h
@@ -566,8 +566,8 @@ int UnpackResourceChunk(rresResourceChunk *chunk)
             };
             crypto_argon2_inputs inputs = {
                 .pass = (const uint8_t *)rresGetCipherPassword(), // User password
-                .pass_size = (uint32_t)strlen(rresGetCipherPassword()), // Password length
                 .salt = salt,                           // Salt for the password
+                .pass_size = (uint32_t)strlen(rresGetCipherPassword()), // Password length
                 .salt_size = 16
             };
             crypto_argon2_extras extras = { 0 };        // Extra parameters unused
@@ -641,8 +641,8 @@ int UnpackResourceChunk(rresResourceChunk *chunk)
             };
             crypto_argon2_inputs inputs = {
                 .pass = (const uint8_t *)rresGetCipherPassword(), // User password
+                .salt = salt,  // Salt for the password
                 .pass_size = (uint32_t)strlen(rresGetCipherPassword()), // Password length
-                .salt = salt,                           // Salt for the password
                 .salt_size = 16
             };
             crypto_argon2_extras extras = { 0 };        // Extra parameters unused
@@ -666,7 +666,7 @@ int UnpackResourceChunk(rresResourceChunk *chunk)
             memcpy(mac, ((unsigned char *)chunk->data.raw) + (chunk->info.packedSize - 16), 16);
 
             // Message decryption requires key, nonce and MAC
-            int decryptResult = crypto_aead_unlock(decryptedData, mac, key, nonce, NULL, 0, chunk->data.raw, (chunk->info.packedSize - 16 - 24 - 16));
+            int decryptResult = crypto_aead_unlock(decryptedData, mac, key, nonce, NULL, 0, (const u8 *)chunk->data.raw, (chunk->info.packedSize - 16 - 24 - 16));
 
             // Wipe secrets if they are no longer needed
             crypto_wipe(nonce, 24);

--- a/src/rres-raylib.h
+++ b/src/rres-raylib.h
@@ -666,7 +666,7 @@ int UnpackResourceChunk(rresResourceChunk *chunk)
             memcpy(mac, ((unsigned char *)chunk->data.raw) + (chunk->info.packedSize - 16), 16);
 
             // Message decryption requires key, nonce and MAC
-            int decryptResult = crypto_aead_unlock(decryptedData, mac, key, nonce, NULL, 0, (const u8 *)chunk->data.raw, (chunk->info.packedSize - 16 - 24 - 16));
+            int decryptResult = crypto_aead_unlock(decryptedData, mac, key, nonce, NULL, 0, (unsigned char *)chunk->data.raw, (chunk->info.packedSize - 16 - 24 - 16));
 
             // Wipe secrets if they are no longer needed
             crypto_wipe(nonce, 24);


### PR DESCRIPTION
Hi ray,
I'm using C++ to use raylib and its related extensions, and I'm finding that rres-raylib.h has an incompatible C++ syntax when building the project, causing the compilation to fail. I make the following changes.

In rres-raylib.h crypto_argon2_inputs error is caused by not assigning values in the required order, and implicitly converting void* to const u8 * causes errors.





