### PR TITLE
adding an ifndef check around RRES_SUPPORT_LOG_INFO

### DIFF
--- a/src/rres.h
+++ b/src/rres.h
@@ -171,8 +171,11 @@
 
 // Simple log system to avoid printf() calls if required
 // NOTE: Avoiding those calls, also avoids const strings memory usage
-#define RRES_SUPPORT_LOG_INFO
-#if defined(RRES_SUPPORT_LOG_INFO)
+#ifndef RRES_SUPPORT_LOG_INFO
+    #define RRES_SUPPORT_LOG_INFO 1
+#endif
+
+#if (RRES_SUPPORT_LOG_INFO == 1)
     #define RRES_LOG(...) printf(__VA_ARGS__)
 #else
     #define RRES_LOG(...)


### PR DESCRIPTION
Wrapping the `RRES_SUPPORT_LOG_INFO` define in an `#ifndef` check instead of directly defining it in the header. This avoids compiler warnings about macros redefinitions.